### PR TITLE
Fix issue where macros would be skipped when tab indentation is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ Macros.prototype.visit = function(str){
  */
 
 Macros.prototype.process = function(js){
-  var re = /^( *\/\/.*)/gm;
+  var re = /^(\s*\/\/.*)/gm;
   var prefix = this.prefix;
   var self = this;
 


### PR DESCRIPTION
Some legacy projects are using tab indentation, and the current regex to process macros does not match whitespace with tabs, only spaces.
